### PR TITLE
Fix helm repo name for CD chart push

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -125,5 +125,5 @@ jobs:
           ARTIFACT_NAME=$(find . -name '*.tgz' -exec basename {} \; | head -n 1)
 
           # Publish the chart
-          helm_repo=${{ steps.login-ecr.outputs.registry }}/charts/${{ github.repository }}
+          helm_repo=${{ steps.login-ecr.outputs.registry }}/${{ github.repository_owner }}/charts
           helm push "$ARTIFACT_NAME" "oci://$helm_repo"


### PR DESCRIPTION
I made a bit of a mess of this in #24. It should be the org prefix only (eg. `gravitational/charts`).