### PR TITLE
Default to non-v-prefixed app version image tag

### DIFF
--- a/charts/missing-container-metrics/Chart.yaml
+++ b/charts/missing-container-metrics/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.24.0
+version: 0.24.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.24.0"
+appVersion: "0.24.1"

--- a/charts/missing-container-metrics/templates/daemon-set.yaml
+++ b/charts/missing-container-metrics/templates/daemon-set.yaml
@@ -42,7 +42,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: DOCKER

--- a/charts/missing-container-metrics/values.yaml
+++ b/charts/missing-container-metrics/values.yaml
@@ -5,7 +5,7 @@
 image:
   repository: public.ecr.aws/gravitational/missing-container-metrics
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion prefixed with v.
+  # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 imagePullSecrets: []


### PR DESCRIPTION
I adjusted this in https://github.com/gravitational/missing-container-metrics/pull/24/changes/dca28ead8556b517913cd83b7ce6970c791857bd to preserve the previous default image tag override behaviour however we actually publish non-prefixed tags so should just be using the app version directly.